### PR TITLE
support build on mac

### DIFF
--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -29,6 +29,6 @@
     "build:init": "rm -rf package-lock.json && rm -rf dist && rm -rf node_modules",
     "build:zip": "zip -rq image-handler.zip . -x template.yml",
     "build:dist": "mkdir dist && mv image-handler.zip dist/",
-    "build": "npm run build:init && npm install --production && npm run build:zip && npm run build:dist"
+    "build": "npm run build:init && npm install --arch=x64 --platform=linux --production && npm run build:zip && npm run build:dist"
   }
 }


### PR DESCRIPTION
by forcing the build script to use linux binaries in npm, you can then deploy the image-handler on its own using MacOS (and possibly windows)